### PR TITLE
Fix behavior when not using rq scheduler

### DIFF
--- a/django_rq_dashboard/views.py
+++ b/django_rq_dashboard/views.py
@@ -115,7 +115,7 @@ class Stats(SuperUserMixin, generic.TemplateView):
                 'queues': [serialize_queue(q) for q in context['queues']],
                 'workers': [serialize_worker(w) for w in context['workers']],
                 'scheduled_queues': [serialize_scheduled_queues(q)
-                                     for q in context['scheduled_queues']],
+                                     for q in context.get('scheduled_queues', [])],
             })
             return HttpResponse(
                 data, content_type='application/json; charset=UTF-8',


### PR DESCRIPTION
When rq scheduler is not used an exception is thrown due to the ``context['scheduled_queue']`` dict access, because the scheduled_queue key is not added in ``the context`` dict at all (line 107). I changed it to return an empty array by default to avoid the exception.