### PR TITLE
properly unpack filter arg

### DIFF
--- a/django_rq_dashboard/views.py
+++ b/django_rq_dashboard/views.py
@@ -230,7 +230,8 @@ class SchedulerDetails(SuperUserMixin, generic.TemplateView):
         scheduler = Scheduler(self.connection)
         queue = Queue(self.kwargs['queue'], connection=self.connection)
 
-        def cond(job, next_run):
+        def cond(job_tuple):
+            job, next_run = job_tuple
             return job.origin == queue.name
         jobs = filter(cond, scheduler.get_jobs(with_times=True))
 


### PR DESCRIPTION
As far as I can tell this is just a logical error -- `filter` builtin does not unpack tuples for you; you have to do it yourself.